### PR TITLE
fixed unreasonably large uncertainties

### DIFF
--- a/ppg147/Appx.0.0.yaml
+++ b/ppg147/Appx.0.0.yaml
@@ -98,79 +98,79 @@ dependent_variables:
   values:
   - value: 0.01098
     errors:
-    - {symerror: 0.01098, label: 'stat'}
-    - {symerror: 1.2e-4, label: 'pT uncor. sys'}
-    - {symerror: 1.0e-4, label: 'pT cor. sys'}
+    - {symerror: 1.2e-4, label: 'stat'}
+    - {symerror: 1.0e-4, label: 'pT uncor. sys'}
+    - {symerror: 8e-4, label: 'pT cor. sys'}
   - value: 0.02034
     errors:
-    - {symerror: 0.02034, label: 'stat'}
-    - {symerror: 1.6e-4, label: 'pT uncor. sys'}
-    - {symerror: 1.8e-4, label: 'pT cor. sys'}
+    - {symerror: 1.6e-4, label: 'stat'}
+    - {symerror: 1.8e-4, label: 'pT uncor. sys'}
+    - {symerror: 0.0013, label: 'pT cor. sys'}
   - value: 0.03072
     errors:
-    - {symerror: 0.03072, label: 'stat'}
-    - {symerror: 2.1e-4, label: 'pT uncor. sys'}
-    - {symerror: 2.7e-4, label: 'pT cor. sys'}
+    - {symerror: 2.1e-4, label: 'stat'}
+    - {symerror: 2.7e-4, label: 'pT uncor. sys'}
+    - {symerror: 0.0019, label: 'pT cor. sys'}
   - value: 0.04068
     errors:
-    - {symerror: 0.04068, label: 'stat'}
-    - {symerror: 2.9e-4, label: 'pT uncor. sys'}
-    - {symerror: 4e-4, label: 'pT cor. sys'}
+    - {symerror: 2.9e-4, label: 'stat'}
+    - {symerror: 4e-4, label: 'pT uncor. sys'}
+    - {symerror: 0.0025, label: 'pT cor. sys'}
   - value: 0.0504
     errors:
-    - {symerror: 0.0504, label: 'stat'}
+    - {symerror: 4e-4, label: 'stat'}
     - {symerror: 4e-4, label: 'pT uncor. sys'}
-    - {symerror: 4e-4, label: 'pT cor. sys'}
+    - {symerror: 0.0031, label: 'pT cor. sys'}
   - value: 0.0599
     errors:
-    - {symerror: 0.0599, label: 'stat'}
+    - {symerror: 5e-4, label: 'stat'}
     - {symerror: 5e-4, label: 'pT uncor. sys'}
-    - {symerror: 5e-4, label: 'pT cor. sys'}
+    - {symerror: 0.004, label: 'pT cor. sys'}
   - value: 0.0659
     errors:
-    - {symerror: 0.0659, label: 'stat'}
-    - {symerror: 7e-4, label: 'pT uncor. sys'}
-    - {symerror: 6e-4, label: 'pT cor. sys'}
+    - {symerror: 7e-4, label: 'stat'}
+    - {symerror: 6e-4, label: 'pT uncor. sys'}
+    - {symerror: 0.004, label: 'pT cor. sys'}
   - value: 0.0715
     errors:
-    - {symerror: 0.0715, label: 'stat'}
-    - {symerror: 9e-4, label: 'pT uncor. sys'}
-    - {symerror: 6e-4, label: 'pT cor. sys'}
+    - {symerror: 9e-4, label: 'stat'}
+    - {symerror: 6e-4, label: 'pT uncor. sys'}
+    - {symerror: 0.004, label: 'pT cor. sys'}
   - value: 0.0788
     errors:
-    - {symerror: 0.0788, label: 'stat'}
-    - {symerror: 0.0012, label: 'pT uncor. sys'}
-    - {symerror: 7e-4, label: 'pT cor. sys'}
+    - {symerror: 0.0012, label: 'stat'}
+    - {symerror: 7e-4, label: 'pT uncor. sys'}
+    - {symerror: 0.005, label: 'pT cor. sys'}
   - value: 0.0786
     errors:
-    - {symerror: 0.0786, label: 'stat'}
-    - {symerror: 0.0017, label: 'pT uncor. sys'}
-    - {symerror: 7e-4, label: 'pT cor. sys'}
+    - {symerror: 0.0017, label: 'stat'}
+    - {symerror: 7e-4, label: 'pT uncor. sys'}
+    - {symerror: 0.005, label: 'pT cor. sys'}
   - value: 0.0840
     errors:
-    - {symerror: 0.0840, label: 'stat'}
-    - {symerror: 0.0024, label: 'pT uncor. sys'}
-    - {symerror: 7e-4, label: 'pT cor. sys'}
+    - {symerror: 0.0024, label: 'stat'}
+    - {symerror: 7e-4, label: 'pT uncor. sys'}
+    - {symerror: 0.005, label: 'pT cor. sys'}
   - value: 0.0842
     errors:
-    - {symerror: 0.0842, label: 'stat'}
-    - {symerror: 0.0035, label: 'pT uncor. sys'}
-    - {symerror: 7e-4, label: 'pT cor. sys'}
+    - {symerror: 0.0035, label: 'stat'}
+    - {symerror: 7e-4, label: 'pT uncor. sys'}
+    - {symerror: 0.005, label: 'pT cor. sys'}
   - value: 0.0862
     errors:
-    - {symerror: 0.0862, label: 'stat'}
-    - {symerror: 0.005, label: 'pT uncor. sys'}
-    - {symerror: 8e-4, label: 'pT cor. sys'}
+    - {symerror: 0.005, label: 'stat'}
+    - {symerror: 8e-4, label: 'pT uncor. sys'}
+    - {symerror: 0.005, label: 'pT cor. sys'}
   - value: 0.0790
     errors:
-    - {symerror: 0.0790, label: 'stat'}
-    - {symerror: 0.006, label: 'pT uncor. sys'}
-    - {symerror: 7e-4, label: 'pT cor. sys'}
+    - {symerror: 0.006, label: 'stat'}
+    - {symerror: 7e-4, label: 'pT uncor. sys'}
+    - {symerror: 0.005, label: 'pT cor. sys'}
   - value: 0.0568
     errors:
-    - {symerror: 0.0568, label: 'stat'}
-    - {symerror: 0.010, label: 'pT uncor. sys'}
-    - {symerror: 5e-4, label: 'pT cor. sys'}
+    - {symerror: 0.010, label: 'stat'}
+    - {symerror: 5e-4, label: 'pT uncor. sys'}
+    - {symerror: 0.0035, label: 'pT cor. sys'}
 - header: {name: '$\pi^{\pm}$ $v_4$ in centrality 10-20%'}
   values:
   - value: 0.00724


### PR DESCRIPTION
A txt file fed to the YAM_Maker had a duplicate column which caused unreasonably large uncertainties for some data series. The new YAML file was regenerated with this issue fixed.