### PR TITLE
Added the InspireHep reference to the submission file and fixed typos

### DIFF
--- a/ppg233/submission.yaml
+++ b/ppg233/submission.yaml
@@ -1,12 +1,13 @@
 # PPG233
+# InsipreHEP: 2050486
 comment: |
-  Small nuclear collisions are mainly sensitive to cold nuclear effects, however, the collective behavior observed in these collisions shows a hint of hot nuclear effects. The identified particle spectra, especially the $\phi$ mesons which contains strange and anti-strange quarks and has a relatively small hadronic interaction cross section, are a good tool to study these effects. The PHENIX experiment has measured $\phi$ mesons in a unique set of small collision systems $p$$+$Al, $p$$+$Al, $^3$He$+$Au at $\sqrt{s_{_{NN}}}=200$ GeV. The transverse momentum spectra and nuclear modification factors are presented and compared to theoretical model predictions. The comparisons with different calculations suggest that quark-gluon plasma may be formed in the small collision systems at $\sqrt{s_{_{NN}}}=200$ GeV. However, the volume and the lifetime of the medium produced in small collision systems may be insufficient for observing strangeness enhancement and jet quenching effects. The comparison with AMPT calculations suggests that the main production mechanisms of $\phi$ mesons may be different in $p$$+$Al collisions and $p/d/^3$He$+$Au collisions at $\sqrt{s_{_{NN}}}=200$ GeV at midrapidity. While thermal quark recombination seems to dominate in $p/d/^3$He$+$Au, fragmentation seems to be the main production mechanism in $p$$+$Al.
+  Small nuclear collisions are mainly sensitive to cold-nuclear-matter effects; however, the collective behavior observed in these collisions shows a hint of hot-nuclear-matter effects. The identified-particle spectra, especially the $\phi$ mesons which contain strange and antistrange quarks and has a relatively small hadronic-interaction cross section, are a good tool to study these effects. The PHENIX experiment has measured $\phi$ mesons in a specific set of small collision systems $p$$+$Al, $p$$+$Au, and $^3$He$+$Au, as well as $d$$+$Au [Phys. Rev. C 83, 024909 (2011)], at $\sqrt{s_{_{NN}}}=200$ GeV. The transverse-momentum spectra and nuclear-modification factors are presented and compared to theoretical-model predictions. The comparisons with different calculations suggest that quark-gluon plasma may be formed in these small collision systems at $\sqrt{s_{_{NN}}}=200$ GeV. However, the volume and the lifetime of the produced medium may be insufficient for observing strangeness-enhancement and jet-quenching effects. The comparison with calculations suggests that the main production mechanisms of $\phi$ mesons at midrapidity may be different in $p$$+$Al versus $p/d/^3$He$+$Au collisions at $\sqrt{s_{_{NN}}}=200$ GeV. While thermal quark recombination seems to dominate in $p/d/^3$He$+$Au collisions, fragmentation seems to be the main production mechanism in $p$$+$Al collisions.
 ---
 additional_resources:
   - {location: thumb_fig3.png, description: Thumbnail Image file}
   - {location: fig3.png, description: Image file}
 name: "Figure3"
-description: 'Invariant transverse momentum spectra measured for $\phi$ mesons in (a) p+Al, (b) p+Au, and (c) $^{3}$He+Au collisions at $\sqrt{s}$ = 200 GeV at midrapidity'
+description: 'Invariant transverse momentum spectra measured for $\phi$ mesons in (a) $p$+Al, (b) $p$+Au, and (c) $^{3}$He+Au collisions at $\sqrt{s_{_{NN}}}$ = 200 GeV at midrapidity.'
 keywords:
   - {name: reactions, values: [ P AL --> NEUTRAL X] }
   - {name: reactions, values: [ P AU --> NEUTRAL X] }
@@ -19,7 +20,7 @@ additional_resources:
   - {location: thumb_fig4.png, description: Thumbnail Image file}
   - {location: fig4.png, description: Image file}
 name: "Figure4"
-description: 'The comparison of $\phi$ meson nuclear modification factors in p+Al, p+Au, d+Au, and $^{3}$He+Au collisions at 200 GeV at midrapidity. The normalization uncertainty from p+p of about 9.7\%  is not shown'
+description: 'Comparison of $\phi$-meson nuclear-modification factors in $p$+Al, $p$+Au, $d$+Au [2], and $^{3}$He+Au collisions at $\sqrt{s_{_{NN}}}$ = 200 GeV at midrapidity. The normalization uncertainty from $p$+$p$ of about $9.7 \%$  is not shown [28].'
 keywords:
   - {name: reactions, values: [ P AL --> NEUTRAL X] }
   - {name: reactions, values: [ P AU --> NEUTRAL X] }
@@ -33,7 +34,7 @@ additional_resources:
   - {location: thumb_fig5.png, description: Thumbnail Image file}
   - {location: fig5.png, description: Image file}
 name: "Figure5"
-description: 'The comparison of $\phi$ meson to $\pi^0$ meson (from Ref. \cite{PPG202}) nuclear modification factors in p+Al, p+Au, d+Au, and $^{3}$He+Au  (a) to (d) central and (e) to (h) peripheral collisions, respectively, at $\sqrt{s}$  = 200 GeV at midrapidity. The normalization uncertainty from p+p ($\sim9.7\%$)  is not shown.'
+description: 'The comparison of $\phi$ meson to $\pi^0$ meson (from Ref. [29]) nuclear-modification factors in $p$+Al, $p$+Au, $d$+Au [2], and $^{3}$He+Au  (a) to (d) central and (e) to (h) peripheral collisions at $\sqrt{s_{_{NN}}}$  = 200 GeV at midrapidity. The normalization uncertainty from $p$+$p$ ($\sim9.7\%$) is not shown.'
 keywords:
   - {name: reactions, values: [ P AU --> NEUTRAL X] }
   - {name: reactions, values: [ P AL --> NEUTRAL X] }
@@ -47,7 +48,7 @@ additional_resources:
   - {location: thumb_fig6.png, description: Thumbnail Image file}
   - {location: fig6.png, description: Image file}
 name: "Figure6"
-description: 'The comparison of the experimental results on $\phi$ meson production in (a) p+Al, (b) p+Au, (c) d+Au, and (d) $^{3}$He+Au collisions at $\sqrt{s}$ = 200 GeV at midrapidity ($|\eta|<0.35$) to PYTHIA/Angatyr model predictions.'
+description: 'Experimental results on $\phi$ meson production in (a) $p$+Al, (b) $p$+Au, (c) $d$+Au [2], and (d) $^{3}$He+Au collisions at $\sqrt{s_{_{NN}}}$ = 200 GeV at midrapidity ($|\eta|<0.35$) and comparisons to PYTHIA/Angantyr [33] model predictions.'
 keywords:
   - {name: reactions, values: [ P AL --> NEUTRAL X] }
   - {name: reactions, values: [ P AU --> NEUTRAL X] }
@@ -61,7 +62,7 @@ additional_resources:
   - {location: thumb_fig7.png, description: Thumbnail Image file}
   - {location: fig7.png, description: Image file}
 name: "Figure7"
-description: 'The comparison of the experimental results on $\phi$ meson production in (a) p+Al, (b) p+Au, (c) d+Au, and (d) $^{3}$He+Au collisions at $\sqrt{s}$ = 200 GeV at midrapidity ($|\eta|<0.35$) to EPPS16 and nCTEQ15 nuclear PDF calculations.'
+description: 'Experimental results on $\phi$ meson production in (a) $p$+Al, (b) $p$+Au, (c) $d$+Au [2], and (d) $^{3}$He+Au collisions at $\sqrt{s_{_{NN}}}$ = 200 GeV at midrapidity ($|\eta|<0.35$) and comparisons to EPPS16 [34] and NCTEQ15 [35] nuclear PDF calculations.'
 keywords:
   - {name: reactions, values: [ P AL --> NEUTRAL X] }
   - {name: reactions, values: [ P AU --> NEUTRAL X] }
@@ -75,7 +76,7 @@ additional_resources:
   - {location: thumb_fig8.png, description: Thumbnail Image file}
   - {location: fig8.png, description: Image file}
 name: "Figure8"
-description: 'The comparison of the experimental results on $\phi$ meson invariant $p_T$ spectra in p+Al, p+Au, d+Au, and $^{3}$He+Au collisions at $\sqrt{s}$ GeV at midrapidity ($|\eta|<0.35$) to (a) default (def) and (b) string melting (sm) versions of the AMPT model predictions. Panels (c) and (d) show data to AMPT calculations ratios, the markers, error bars, and error boxes are, respectively, the same as for panels (a) and (b).'
+description: 'Experimental results on $\phi$ meson invariant $p_T$ spectra in $p$+Al, $p$+Au, $d$+Au [2], and $^{3}$He+Au collisions at $\sqrt{s_{_{NN}}}$ GeV at midrapidity ($|\eta|<0.35$) to (a) default [def] and (b) string melting [sm] versions of the AMPT-model predictions. Panels (c) and (d) show data to AMPT-calculations ratios; the markers, error bars, and error boxes are the same as for panels (a) and (b).'
 keywords:
   - {name: reactions, values: [ P AL --> NEUTRAL X] }
   - {name: reactions, values: [ P AU --> NEUTRAL X] }


### PR DESCRIPTION
Added the InspireHep reference to the submission file. The typos were fixed in the submission file: Corrected the reference in the Fig.5 caption; Abstract and figure captions were updated according the arXiv version of the paper.