### PR TITLE
Include polarization scale uncertainty in tables

### DIFF
--- a/ppg246/submission.yaml
+++ b/ppg246/submission.yaml
@@ -18,7 +18,7 @@ additional_resources:
 - {description: Image file, location: fig1.png}
 - {description: Thumbnail Image file, location: thumb_fig1.png}
 data_file: table246_0.yaml
-description: Data from Figure 1 of open heavy flavor $e^{\pm}$ single spin asymmetries in transversely polarized p+p collisions as a function of $p_{T}$. An additional scale uncertainty of 3.4% due to the polarization uncertainty is not shown. 
+description: Data from Figure 1 of open heavy flavor $e^{\pm}$ transverse single-spin asymmetries in transversely polarized p+p collisions as a function of $p_{T}$.
 keywords:
 - {name: reactions, values: [P P --> HEAVY-FLAVOR X, Heavy-Flavor --> E+ X, Heavy-Flavor --> E- X]}
 - {name: observables, values: [ASYM]}

--- a/ppg246/table246_0.yaml
+++ b/ppg246/table246_0.yaml
@@ -16,26 +16,32 @@ dependent_variables:
     errors:
     - {symerror: 0.0212, label: 'Statistical'}
     - {asymerror: {plus: 0.00330, minus: -0.00281 }, label: 'Systematic'}
+    - {asymerror: {plus: 0.0000842, minus: -0.0000901}, label: 'Scaling uncertainty due to polarization'}
   - value: 0.0105
     errors:
     - {symerror: 0.0178, label: 'Statistical'}
     - {asymerror: {plus: 0.00211, minus: -0.00189 }, label: 'Systematic'}
+    - {asymerror: {plus: 0.000345, minus: -0.000370}, label: 'Scaling uncertainty due to polarization'}
   - value: 0.00571
     errors:
     - {symerror: 0.0159, label: 'Statistical'}
     - {asymerror: {plus: 0.00134, minus: -0.00132 }, label: 'Systematic'}
+    - {asymerror: {plus: 0.000188, minus: -0.000201}, label: 'Scaling uncertainty due to polarization'}
   - value: 0.0126
     errors:
     - {symerror: 0.0192, label: 'Statistical'}
     - {asymerror: {plus: 0.00710, minus: -0.00708 }, label: 'Systematic'}
+    - {asymerror: {plus: 0.000414, minus: -0.000443}, label: 'Scaling uncertainty due to polarization'}
   - value: 0.00208
     errors:
     - {symerror: 0.0210, label: 'Statistical'}
     - {asymerror: {plus: 0.00473, minus: -0.00465 }, label: 'Systematic'}
+    - {asymerror: {plus: 0.0000684, minus: -0.0000732}, label: 'Scaling uncertainty due to polarization'}
   - value: 0.0357
     errors:
     - {symerror: 0.0287, label: 'Statistical'}
     - {asymerror: {plus: 0.00688, minus: -0.00501 }, label: 'Systematic'}
+    - {asymerror: {plus: 0.00117, minus: -0.00126}, label: 'Scaling uncertainty due to polarization'}
 - header: {name: '$A_{N}^{OHF \rightarrow e^{-}}$'}
   qualifiers:
   - {name: '$p_{T}$ GeV/c', value: '$A_{N}^{OHF \rightarrow e^{-}}$, $p^{\uparrow}$$+$$p$ $\sqrt{s} = 200$ GeV, $|\eta|<0.35$'}
@@ -44,23 +50,29 @@ dependent_variables:
     errors:
     - {symerror: 0.0186, label: 'Statistical'}
     - {asymerror: {plus: 0.00474, minus: -0.00343 }, label: 'Systematic'}
+    - {asymerror: {plus: 0.000372, minus: -0.000398}, label: 'Scaling uncertainty due to polarization'}
   - value: -0.0297
     errors:
     - {symerror: 0.0181, label: 'Statistical'}
     - {asymerror: {plus: 0.00502, minus: -0.00384 }, label: 'Systematic'}
+    - {asymerror: {plus: 0.000977, minus: -0.00104}, label: 'Scaling uncertainty due to polarization'}
   - value: 0.0139
     errors:
     - {symerror: 0.0167, label: 'Statistical'}
     - {asymerror: {plus: 0.00209, minus: -0.00191 }, label: 'Systematic'}
+    - {asymerror: {plus: 0.000457, minus: -0.000489}, label: 'Scaling uncertainty due to polarization'}
   - value: 0.0105
     errors:
     - {symerror: 0.0207, label: 'Statistical'}
     - {asymerror: {plus: 0.00176, minus: -0.00149 }, label: 'Systematic'}
+    - {asymerror: {plus: 0.000345, minus: -0.000370}, label: 'Scaling uncertainty due to polarization'}
   - value: -0.0267
     errors:
     - {symerror: 0.0227, label: 'Statistical'}
     - {asymerror: {plus: 0.00269, minus: -0.00269 }, label: 'Systematic'}
+    - {asymerror: {plus: 0.000878, minus: -0.000940}, label: 'Scaling uncertainty due to polarization'}
   - value: 0.0237
     errors:
     - {symerror: 0.0305, label: 'Statistical'}
     - {asymerror: {plus: 0.00541, minus: -0.00363 }, label: 'Systematic'}
+    - {asymerror: {plus: 0.000779, minus: -0.000834}, label: 'Scaling uncertainty due to polarization'}


### PR DESCRIPTION
Updated the data tables to include the polarization scale uncertainty in each bin, and updated the description of Figure 1 accordingly (it used to state that the polarization scale uncertainty was not included in the table).