### PR TITLE
Fix ppg234 texts in the file: submission.yaml

### DIFF
--- a/ppg256/submission.yaml
+++ b/ppg256/submission.yaml
@@ -13,7 +13,7 @@
 comment: |
   BNL-RHIC. The $J/#psi$ and $#psi(2S)$ charmonium states, composed of $c\bar{c}$ quark pairs and known since the 1970s, are widely believed to serve as ideal probes to test quantum chromodynamics (QCD) in high-energy hadronic interactions. However, a complete understanding of the charmonium production mechanism has not yet been achieved. Recent measurements of $J/#psi$ production as a function of event charged particle multiplicity at both LHC and RHIC energies show enhanced $J/#psi$ production yields with increasing multiplicity. One potential explanation for this type of dependence is Multi-Parton Interactions (MPI). We carry out the first measurements of self-normalized $J/#psi$ yields and the $#psi(2S)$ to $J/#psi$ ratio at both forward and backward rapidities as a function of self-normalized charged particle multiplicity in $pp$ collisions at $\sqrt{s}$ = 200 GeV. In addition, detailed PYTHIA studies tuned to RHIC energies have been performed to investigate the MPI impacts. We find that the PHENIX data are consistent with recent LHC measurements and can only be described by PYTHIA calculations that include MPI effects. The forward and backward $#psi(2S)$/$J/#psi$ ratio, which serves as a unique and powerful approach to study final state effects on charmonium production, is found to be less dependent on the charged particle multiplicity. 
 additional_resources:
-  - {location: "https://www.phenix.bnl.gov/phenix/WWW/info/data/ppg243_data.html", description: "web page with data points"}
+  - {location: "https://phenix-intra.sdcc.bnl.gov/phenix/WWW/p/info/dp2/256/", description: "official PHENIX webpage for the analysis"}
   - {description: arXiv link, location: 'https://arxiv.org/abs/2409.03728'}   
 ---
 additional_resources:


### PR DESCRIPTION
I fixed the ppg234 texts in the submission.yaml file for ppg256 HEPDATA. I replace it with the PPG directory on the official PHENIX webpage.